### PR TITLE
Improve pheromone context handoffs

### DIFF
--- a/.pheromone
+++ b/.pheromone
@@ -6,7 +6,15 @@
       "target": "project_guidance",
       "category": "compass",
       "strength": 10.0,
-      "message": "Project blueprint loaded"
+      "message": "Project blueprint loaded",
+      "context": {
+        "modified_files": ["@docs/NewProject_Alpha_Blueprint.md"],
+        "key_decisions": ["adopt async architecture"],
+        "handoff_instructions": "validate blueprint feasibility",
+        "verification": {"tests_passed": true},
+        "token_usage": 120,
+        "complexity_score": 5
+      }
     },
     {
       "id": "framework-scaffolding-needed-001",
@@ -14,7 +22,15 @@
       "target": "coder-test-driven",
       "category": "need",
       "strength": 8.0,
-      "message": "Framework scaffolding required"
+      "message": "Framework scaffolding required",
+      "context": {
+        "modified_files": [],
+        "key_decisions": ["use fastapi"],
+        "handoff_instructions": "generate project skeleton",
+        "verification": {"tests_passed": false},
+        "token_usage": 60,
+        "complexity_score": 4
+      }
     },
     {
       "id": "feature-spec-complete-001",
@@ -22,7 +38,15 @@
       "target": "all_agents",
       "category": "state",
       "strength": 7.5,
-      "message": "Feature specification completed"
+      "message": "Feature specification completed",
+      "context": {
+        "modified_files": ["@specs/feature_spec.md"],
+        "key_decisions": ["coverage targets set"],
+        "handoff_instructions": "start implementation",
+        "verification": {"code_quality": "ok"},
+        "token_usage": 90,
+        "complexity_score": 3
+      }
     },
     {
       "id": "integration-conflict-detected-001",
@@ -30,7 +54,15 @@
       "target": "orchestrator",
       "category": "block",
       "strength": 9.0,
-      "message": "Integration conflict detected in module API"
+      "message": "Integration conflict detected in module API",
+      "context": {
+        "modified_files": ["@src/api.py"],
+        "key_decisions": ["rollback integration"],
+        "handoff_instructions": "resolve merge issues",
+        "verification": {"security_scan": "pending"},
+        "token_usage": 30,
+        "complexity_score": 6
+      }
     },
     {
       "id": "peer-coordination-established-001",
@@ -38,7 +70,15 @@
       "target": "orchestrator_network",
       "category": "coordinate",
       "strength": 7.0,
-      "message": "Peer coordination established"
+      "message": "Peer coordination established",
+      "context": {
+        "modified_files": [],
+        "key_decisions": ["notify orchestrators"],
+        "handoff_instructions": "monitor progress",
+        "verification": {},
+        "token_usage": 10,
+        "complexity_score": 2
+      }
     }
   ]
 }

--- a/.swarmConfig
+++ b/.swarmConfig
@@ -56,5 +56,19 @@
   },
   "enhancedIntelligenceConfig": {
     "patternMatching": true
+  },
+  "contextConfig": {
+    "maxTokens": 500,
+    "retentionPolicy": "compress"
+  },
+  "signalSchema": {
+    "context": [
+      "modified_files",
+      "key_decisions",
+      "handoff_instructions",
+      "verification",
+      "token_usage",
+      "complexity_score"
+    ]
   }
 }

--- a/src/context_manager.py
+++ b/src/context_manager.py
@@ -1,0 +1,46 @@
+import re
+import json
+from typing import Any, Dict, List
+
+
+class ContextError(Exception):
+    """Custom exception for context management issues."""
+
+
+def extract_decisions(summary: str) -> List[str]:
+    """Extract decision statements from an agent summary."""
+    decisions = []
+    for line in summary.splitlines():
+        if line.strip().lower().startswith(('decided', 'decision', '*')):
+            decisions.append(line.strip())
+    return decisions
+
+
+def compress_context(context: Dict[str, Any], max_tokens: int = 500) -> Dict[str, Any]:
+    """Truncate long fields to keep context under token limits."""
+    compressed = {}
+    token_count = 0
+    for key, value in context.items():
+        text = json.dumps(value) if not isinstance(value, str) else value
+        tokens = len(text.split())
+        if token_count + tokens > max_tokens:
+            break
+        compressed[key] = value
+        token_count += tokens
+    return compressed
+
+
+def validate_files(files: List[str]) -> List[str]:
+    """Validate and format file references."""
+    valid = []
+    pattern = re.compile(r'^[\w./-]+$')
+    for f in files:
+        if pattern.match(f) and ".." not in f and " " not in f:
+            valid.append(f"@{f}")
+    return valid
+
+
+def verify_progress(previous: Dict[str, Any], current: Dict[str, Any]) -> bool:
+    """Check if progress has been made between contexts."""
+    return previous != current
+

--- a/src/pheromone_helpers.py
+++ b/src/pheromone_helpers.py
@@ -1,0 +1,68 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .context_manager import compress_context, validate_files
+
+
+class PheromoneError(Exception):
+    """Custom exception for pheromone update issues."""
+
+
+async def load_pheromone(path: str) -> Dict[str, Any]:
+    """Load pheromone JSON asynchronously."""
+    try:
+        text = await asyncio.to_thread(Path(path).read_text)
+        return json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PheromoneError("Invalid pheromone file") from exc
+
+
+async def save_pheromone(path: str, data: Dict[str, Any]) -> None:
+    """Persist pheromone JSON asynchronously."""
+    try:
+        await asyncio.to_thread(Path(path).write_text, json.dumps(data, indent=2))
+    except OSError as exc:
+        raise PheromoneError("Unable to save pheromone") from exc
+
+
+def calculate_strength(category: str, complexity: int, urgency: float) -> float:
+    """Calculate signal strength from complexity and urgency."""
+    base = {
+        'compass': 10.0,
+        'state': 7.5,
+        'need': 7.0,
+        'block': 8.5,
+        'coordinate': 6.5,
+    }.get(category, 1.0)
+    return min(10.0, base + complexity * 0.1 + urgency)
+
+
+def sanitize_context(context: Dict[str, Any]) -> Dict[str, Any]:
+    """Sanitize context fields and compress."""
+    files = context.get('modified_files', [])
+    context['modified_files'] = validate_files(files)
+    return compress_context(context)
+
+
+async def update_pheromone(path: str, signal: Dict[str, Any]) -> None:
+    """Update pheromone file with a sanitized signal."""
+    pheromone = await load_pheromone(path)
+    context = sanitize_context(signal.get('context', {}))
+    signal['context'] = context
+    pheromone.setdefault('signals', []).append(signal)
+    pheromone['signals'] = consolidate_signals(pheromone['signals'])
+    await save_pheromone(path, pheromone)
+
+
+def consolidate_signals(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Merge consecutive signals referencing the same files."""
+    consolidated: List[Dict[str, Any]] = []
+    for sig in signals:
+        if consolidated and sig.get('context', {}).get('modified_files') == consolidated[-1].get('context', {}).get('modified_files'):
+            consolidated[-1]['message'] += f"; {sig['message']}"
+        else:
+            consolidated.append(sig)
+    return consolidated
+

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,37 @@
+import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.context_manager import (
+    extract_decisions,
+    compress_context,
+    validate_files,
+    verify_progress,
+)
+
+
+def test_extract_decisions():
+    summary = """Decision: adopt API\n* Use async functions\nNo action"""
+    decisions = extract_decisions(summary)
+    assert len(decisions) == 2
+
+
+def test_compress_context():
+    ctx = {"a": "word " * 300, "b": "ok"}
+    compressed = compress_context(ctx, max_tokens=50)
+    assert "b" not in compressed or compressed.get("b") == "ok"
+
+
+def test_validate_files():
+    files = ["src/app.py", "invalid file", "../bad"]
+    valid = validate_files(files)
+    assert "@src/app.py" in valid
+    assert len(valid) == 1
+
+
+def test_verify_progress():
+    prev = {"a": 1}
+    curr = {"a": 2}
+    assert verify_progress(prev, curr)

--- a/tests/test_pheromone_helpers.py
+++ b/tests/test_pheromone_helpers.py
@@ -1,0 +1,30 @@
+import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.pheromone_helpers import sanitize_context, calculate_strength, consolidate_signals
+
+
+@pytest.mark.asyncio
+async def test_calculate_strength():
+    strength = calculate_strength("need", 5, 0.5)
+    assert strength > 7
+
+
+def test_sanitize_context(tmp_path):
+    ctx = {"modified_files": ["src/main.py", "bad path"], "handoff_instructions": "continue"}
+    result = sanitize_context(ctx)
+    assert result["modified_files"] == ["@src/main.py"]
+
+
+@pytest.mark.asyncio
+async def test_consolidate_signals():
+    signals = [
+        {"message": "a", "context": {"modified_files": ["@f"]}},
+        {"message": "b", "context": {"modified_files": ["@f"]}},
+    ]
+    consolidated = consolidate_signals(signals)
+    assert len(consolidated) == 1
+    assert "b" in consolidated[0]["message"]


### PR DESCRIPTION
## Summary
- preserve context in pheromone signals
- add context_manager module for decision extraction and compression
- add pheromone_helpers module for managing pheromone updates
- store context schema in `.swarmConfig`
- tests for new context features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6fec79f4832280eb9d175ffc1d09