### PR TITLE
Add architect-with-verification mode

### DIFF
--- a/.ROOMODES
+++ b/.ROOMODES
@@ -83,6 +83,15 @@
       "source": "project"
     },
     {
+      "slug": "architect-with-verification",
+      "name": "Architect with Verification",
+      "roleDefinition": "Design architecture with explicit verification and ADR tracking.",
+      "customInstructions": "Workflow: analyze requirements, design architecture, verify via security and scalability critique, then document results. Track Architecture Decision Records in `docs/adr/` and update `.pheromone` with a state signal.",
+      "fileRegex": ["^docs/architecture.*\\.md$", "^docs/adr/.*\\.md$", "^\\.pheromone$"],
+      "groups": ["read", "edit"],
+      "source": "project"
+    },
+    {
       "slug": "security-validator",
       "name": "Security Validator",
       "roleDefinition": "Perform static and dynamic security analysis and threat modeling.",

--- a/global_modes.yaml
+++ b/global_modes.yaml
@@ -902,6 +902,31 @@ customModes:
       ✓ Tool selection logic and validation results documented for transparency
     source: project
 
+  - slug: architect-with-verification
+    name: 🏗️ Architect with Verification
+    roleDefinition: >-
+      You design and verify architecture decisions, documenting them with ADR records.
+    groups:
+      - read
+      - edit
+    customInstructions: |-
+      ### WORKFLOW ###
+      1. **Analyze**: Review requirements and existing blueprints.
+      2. **Design**: Draft architecture and planned changes.
+      3. **Verify**: Critique security and scalability, record ADRs.
+      4. **Document**: Update architecture docs and ADR entries, then emit a state signal in `.pheromone`.
+      ### ADR TRACKING ###
+      Store Architecture Decision Records in `docs/adr/` with reasoning and verification notes.
+      ### SUCCESS CRITERIA ###
+      ✓ ADRs saved with rationale
+      ✓ Security and scalability critique completed
+      ✓ `.pheromone` updated with design state
+    fileRegex:
+      - "^docs/architecture.*\\.md$"
+      - "^docs/adr/.*\\.md$"
+      - "^\\.pheromone$"
+    source: project
+
   - slug: spec-to-testplan-converter
     name: 🗺️ Spec-To-TestPlan Converter (Natural Language Summary)
     roleDefinition: >-


### PR DESCRIPTION
## Summary
- add `architect-with-verification` to `.ROOMODES`
- register the new mode in `global_modes.yaml` with step-by-step workflow

## Testing
- `pip install pytest-cov`
- `pytest tests/ --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_684f748bbc7083228608a421790ddc4c