### PR TITLE
Add architecture diagram generation module

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,8 @@
+# Architecture Diagrams
+
+The diagrams below visualize the active signals from `.pheromone`.
+
+- [Signal Flow](signal_flow.mmd)
+- [File Dependencies](file_dependencies.mmd)
+
+Open these `.mmd` files with a Mermaid preview tool to render the diagrams.

--- a/docs/architecture/file_dependencies.mmd
+++ b/docs/architecture/file_dependencies.mmd
@@ -1,0 +1,4 @@
+graph TD
+    project_compass--> docs_NewProject_Alpha_Blueprint_md
+    feature_specification_complete--> specs_feature_spec_md
+    integration_conflict_detected--> src_api_py

--- a/docs/architecture/signal_flow.mmd
+++ b/docs/architecture/signal_flow.mmd
@@ -1,0 +1,6 @@
+graph TD
+    project_compass--> project_guidance
+    framework_scaffolding_needed--> coder-test-driven
+    feature_specification_complete--> all_agents
+    integration_conflict_detected--> orchestrator
+    peer_coordination_established--> orchestrator_network

--- a/src/architecture_diagrams.py
+++ b/src/architecture_diagrams.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class DiagramError(Exception):
+    """Raised on diagram generation failures."""
+
+
+PHEROMONE_FILE = os.getenv("PHEROMONE_FILE", ".pheromone")
+
+
+def _validate_path(path: str) -> None:
+    """Ensure the path is safe for file operations."""
+    if ".." in path or Path(path).expanduser().as_posix().startswith("~"):
+        raise DiagramError("Invalid path")
+
+
+async def load_signals(path: str = PHEROMONE_FILE) -> List[Dict[str, Any]]:
+    """Load signals from a pheromone file."""
+    _validate_path(path)
+    try:
+        text = await asyncio.to_thread(Path(path).read_text)
+        data = json.loads(text)
+        return data.get("signals", [])
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DiagramError("Unable to read pheromone") from exc
+
+
+def _node_id(name: str) -> str:
+    return name.replace("@", "").replace("/", "_").replace(".", "_")
+
+
+def create_signal_flow(signals: List[Dict[str, Any]]) -> str:
+    """Return Mermaid graph linking signal types to targets."""
+    lines = ["graph TD"]
+    for sig in signals:
+        src = _node_id(sig.get("signalType", "unknown"))
+        tgt = _node_id(sig.get("target", sig.get("category", "unknown")))
+        lines.append(f"    {src}--> {tgt}")
+    return "\n".join(lines)
+
+
+def create_dependency_graph(signals: List[Dict[str, Any]]) -> str:
+    """Return Mermaid graph linking signals to files."""
+    lines = ["graph TD"]
+    for sig in signals:
+        src = _node_id(sig.get("signalType", "unknown"))
+        files = sig.get("context", {}).get("modified_files", [])
+        for f in files:
+            tgt = _node_id(f)
+            lines.append(f"    {src}--> {tgt}")
+    return "\n".join(lines)
+
+
+async def write_diagrams(directory: str = "docs/architecture") -> List[str]:
+    """Generate diagrams from the current pheromone file."""
+    _validate_path(directory)
+    signals = await load_signals()
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    flow = create_signal_flow(signals)
+    deps = create_dependency_graph(signals)
+    flow_path = Path(directory) / "signal_flow.mmd"
+    dep_path = Path(directory) / "file_dependencies.mmd"
+    await asyncio.to_thread(flow_path.write_text, flow)
+    await asyncio.to_thread(dep_path.write_text, deps)
+    return [str(flow_path), str(dep_path)]
+
+
+async def main() -> None:
+    paths = await write_diagrams()
+    for p in paths:
+        print(f"Diagram written to {p}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_architecture_diagrams.py
+++ b/tests/test_architecture_diagrams.py
@@ -1,0 +1,49 @@
+import pytest
+import json
+import asyncio
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.architecture_diagrams import (
+    load_signals,
+    create_signal_flow,
+    create_dependency_graph,
+    write_diagrams,
+    DiagramError,
+)
+
+
+@pytest.mark.asyncio
+async def test_load_signals(tmp_path):
+    data = {"signals": [{"signalType": "a"}]}
+    f = tmp_path / "p.json"
+    f.write_text(json.dumps(data))
+    signals = await load_signals(str(f))
+    assert signals[0]["signalType"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_load_signals_bad(tmp_path):
+    f = tmp_path / "bad.json"
+    f.write_text("{")
+    with pytest.raises(DiagramError):
+        await load_signals(str(f))
+
+
+def test_mermaid_generation():
+    signals = [{"signalType": "a", "target": "b", "context": {"modified_files": ["@x"]}}]
+    flow = create_signal_flow(signals)
+    deps = create_dependency_graph(signals)
+    assert "a--> b" in flow
+    assert "a--> x" in deps
+
+
+@pytest.mark.asyncio
+async def test_write_diagrams(tmp_path, monkeypatch):
+    monkeypatch.setenv("PHEROMONE_FILE", str(tmp_path / "p.json"))
+    (tmp_path / "p.json").write_text(json.dumps({"signals": []}))
+    paths = await write_diagrams(str(tmp_path / "out"))
+    assert Path(paths[0]).exists() and Path(paths[1]).exists()
+


### PR DESCRIPTION
## Summary
- generate signal flow and file dependency diagrams from `.pheromone`
- output Mermaid `.mmd` diagrams under `docs/architecture`
- link new diagrams in architecture docs
- cover functionality with unit tests

## Testing
- `pytest tests/ --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_684f755d4a54832285fbc2e966274a3e