### PR TITLE
Add ADR template and architecture health tool

### DIFF
--- a/docs/ADRs/0000-template.md
+++ b/docs/ADRs/0000-template.md
@@ -1,0 +1,14 @@
+# Architecture Decision Record Template
+
+## Status
+Proposed
+
+## Context
+Brief context for the decision.
+
+## Decision
+The decision that was made.
+
+## Consequences
+Consequences of adopting the decision.
+

--- a/scripts/architecture_health.py
+++ b/scripts/architecture_health.py
@@ -1,0 +1,78 @@
+import asyncio
+import re
+from pathlib import Path
+from typing import Dict
+
+from src.pheromone_helpers import (
+    update_pheromone,
+    calculate_strength,
+    PheromoneError,
+)
+
+
+class HealthError(Exception):
+    """Raised when architecture health computation fails."""
+
+
+async def _safe_read(path: Path) -> str:
+    try:
+        return await asyncio.to_thread(path.read_text)
+    except OSError as exc:
+        raise HealthError(f"Unable to read {path}") from exc
+
+
+async def find_todos(directory: str) -> int:
+    """Count TODO markers in a directory."""
+    total = 0
+    for file in Path(directory).rglob("*.py"):
+        text = await _safe_read(file)
+        total += len(re.findall(r"TODO", text))
+    return total
+
+
+async def parse_adrs(directory: str) -> Dict[str, int]:
+    """Return ADR statistics."""
+    accepted = 0
+    total = 0
+    for file in Path(directory).glob("*.md"):
+        text = await _safe_read(file)
+        if "Status" in text:
+            total += 1
+            if re.search(r"Status:\s*Accepted", text):
+                accepted += 1
+    return {"accepted": accepted, "total": total}
+
+
+async def update_architecture_health(
+    pheromone_path: str = ".pheromone",
+    src_dir: str = "src",
+    adr_dir: str = "docs/ADRs",
+) -> None:
+    """Compute health metrics and update pheromone."""
+    try:
+        debt = await find_todos(src_dir)
+        patterns = await parse_adrs(adr_dir)
+        msg = f"debt:{debt} patterns:{patterns['accepted']}/{patterns['total']}"
+        signal = {
+            "signalType": "architecture_health",
+            "category": "state",
+            "strength": calculate_strength("state", patterns["total"], 0),
+            "message": msg,
+            "context": {
+                "technical_debt": debt,
+                "pattern_success": patterns,
+                "modified_files": [],
+                "complexity_score": patterns["total"],
+            },
+        }
+        await update_pheromone(pheromone_path, signal)
+    except PheromoneError as exc:
+        raise HealthError("Failed to update pheromone") from exc
+
+
+async def main() -> None:
+    await update_architecture_health()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/pheromone_helpers.py
+++ b/src/pheromone_helpers.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
+import re
 from pathlib import Path
 from typing import Any, Dict, List
 
-from .context_manager import compress_context, validate_files
+from .context_manager import compress_context, validate_files, extract_decisions
 
 
 class PheromoneError(Exception):
@@ -30,29 +31,34 @@ async def save_pheromone(path: str, data: Dict[str, Any]) -> None:
 def calculate_strength(category: str, complexity: int, urgency: float) -> float:
     """Calculate signal strength from complexity and urgency."""
     base = {
-        'compass': 10.0,
-        'state': 7.5,
-        'need': 7.0,
-        'block': 8.5,
-        'coordinate': 6.5,
+        "compass": 10.0,
+        "state": 7.5,
+        "need": 7.0,
+        "block": 8.5,
+        "coordinate": 6.5,
     }.get(category, 1.0)
     return min(10.0, base + complexity * 0.1 + urgency)
 
 
 def sanitize_context(context: Dict[str, Any]) -> Dict[str, Any]:
     """Sanitize context fields and compress."""
-    files = context.get('modified_files', [])
-    context['modified_files'] = validate_files(files)
+    files = context.get("modified_files", [])
+    context["modified_files"] = validate_files(files)
+    summary = context.get("architecture_summary", "")
+    if summary:
+        context["architecture_decisions"] = extract_decisions(summary)
+        pattern_rx = re.compile(r"([A-Z][a-zA-Z]+ Pattern)")
+        context["patterns_used"] = pattern_rx.findall(summary)
     return compress_context(context)
 
 
 async def update_pheromone(path: str, signal: Dict[str, Any]) -> None:
     """Update pheromone file with a sanitized signal."""
     pheromone = await load_pheromone(path)
-    context = sanitize_context(signal.get('context', {}))
-    signal['context'] = context
-    pheromone.setdefault('signals', []).append(signal)
-    pheromone['signals'] = consolidate_signals(pheromone['signals'])
+    context = sanitize_context(signal.get("context", {}))
+    signal["context"] = context
+    pheromone.setdefault("signals", []).append(signal)
+    pheromone["signals"] = consolidate_signals(pheromone["signals"])
     await save_pheromone(path, pheromone)
 
 
@@ -60,9 +66,10 @@ def consolidate_signals(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Merge consecutive signals referencing the same files."""
     consolidated: List[Dict[str, Any]] = []
     for sig in signals:
-        if consolidated and sig.get('context', {}).get('modified_files') == consolidated[-1].get('context', {}).get('modified_files'):
-            consolidated[-1]['message'] += f"; {sig['message']}"
+        if consolidated and sig.get("context", {}).get(
+            "modified_files"
+        ) == consolidated[-1].get("context", {}).get("modified_files"):
+            consolidated[-1]["message"] += f"; {sig['message']}"
         else:
             consolidated.append(sig)
     return consolidated
-

--- a/tests/test_architecture_health.py
+++ b/tests/test_architecture_health.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.architecture_health import (
+    find_todos,
+    parse_adrs,
+    update_architecture_health,
+)
+
+
+@pytest.mark.asyncio
+async def test_find_todos(tmp_path):
+    file = tmp_path / "a.py"
+    file.write_text("# TODO fix\nprint('x')\n")
+    count = await find_todos(str(tmp_path))
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_adrs(tmp_path):
+    adr = tmp_path / "0001.md"
+    adr.write_text("Status: Accepted")
+    stats = await parse_adrs(str(tmp_path))
+    assert stats == {"accepted": 1, "total": 1}
+
+
+@pytest.mark.asyncio
+async def test_update_architecture_health(tmp_path):
+    pher = tmp_path / "p.json"
+    pher.write_text(json.dumps({"signals": []}))
+    adr_dir = tmp_path / "adrs"
+    adr_dir.mkdir()
+    (adr_dir / "0001.md").write_text("Status: Accepted")
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "a.py").write_text("# TODO\n")
+    await update_architecture_health(str(pher), str(src_dir), str(adr_dir))
+    data = json.loads(pher.read_text())
+    assert data["signals"][0]["signalType"] == "architecture_health"


### PR DESCRIPTION
## Summary
- create `docs/ADRs` with a basic ADR template
- improve `sanitize_context` in `pheromone_helpers` to capture architecture decisions and patterns
- add `architecture_health.py` script to compute debt and pattern statistics
- test new health script

## Testing
- `pytest tests/ --cov=src --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7682c75c8322995f2bf7d2901464