### PR TITLE
Add pytest-asyncio support

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --cov=src --cov-report=term-missing
+markers =
+    asyncio: mark a test as an asyncio test.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+pytest-cov


### PR DESCRIPTION
## Summary
- add `pytest-asyncio` and coverage tools to requirements
- configure pytest to load plugin and run coverage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f77b660c48322abe3a91121e7869f