### PR TITLE
Add standardized handoff templates and scripts

### DIFF
--- a/.ROOMODES
+++ b/.ROOMODES
@@ -19,7 +19,7 @@
       "slug": "concept-to-blueprint-translator",
       "name": "Concept to Blueprint Translator",
       "roleDefinition": "Translate user concepts into a swarm-ready project blueprint.",
-      "customInstructions": "Use chain-of-thought notes to outline goals, then apply `docs/NewProject_Alpha_Blueprint.md`. Verify the output path exists, update token usage and complexity score, and emit a `state` signal referencing the blueprint.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps",
+      "customInstructions": "Use chain-of-thought notes to outline goals, then apply `docs/NewProject_Alpha_Blueprint.md`. Verify the output path exists, update token usage and complexity score, and emit a `state` signal referencing the blueprint.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps\nExample: run `python -m scripts.handoff_scripts blueprint_complete_handoff` to notify the architect",
       "fileRegex": [
         "^docs/.*\\.md$",
         "^\\.pheromone$"
@@ -77,7 +77,7 @@
       "slug": "coder-test-driven",
       "name": "Coder",
       "roleDefinition": "Implement features with tests following TDD principles.",
-      "customInstructions": "Plan with chain-of-thought reasoning, then code using async I/O and custom exceptions. Track token usage and complexity score. Commit changes with a `state` signal summarizing files.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps",
+      "customInstructions": "Plan with chain-of-thought reasoning, then code using async I/O and custom exceptions. Track token usage and complexity score. Commit changes with a `state` signal summarizing files.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps\nExample: run `python -m scripts.handoff_scripts code_complete_handoff` to notify the tester",
       "fileRegex": [
         "^src/.*\\.py$",
         "^tests/.*\\.py$",
@@ -93,7 +93,7 @@
       "slug": "debugger-targeted",
       "name": "Debugger",
       "roleDefinition": "Diagnose and fix issues reported by failing tests or bug reports.",
-      "customInstructions": "Use chain-of-thought analysis to trace failures. Apply minimal fixes, and escalate with a `block` signal if unresolved after two attempts. Record token usage and complexity.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps",
+      "customInstructions": "Use chain-of-thought analysis to trace failures. Apply minimal fixes, and escalate with a `block` signal if unresolved after two attempts. Record token usage and complexity.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps\nExample: run `python -m scripts.handoff_scripts debug_complete_handoff tester-tdd-master` after fixing a bug",
       "fileRegex": [
         "^src/.*\\.py$",
         "^tests/.*\\.py$",
@@ -109,7 +109,7 @@
       "slug": "tester-tdd-master",
       "name": "Tester",
       "roleDefinition": "Run automated tests and report coverage results.",
-      "customInstructions": "Execute `pytest` with retry logic. Ensure coverage stays above 80%, escalate with a `block` signal if below. Document pass/fail counts and token usage.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps",
+      "customInstructions": "Execute `pytest` with retry logic. Ensure coverage stays above 80%, escalate with a `block` signal if below. Document pass/fail counts and token usage.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps\nExample: run `python -m scripts.handoff_scripts test_complete_handoff` when tests pass or `python -m scripts.handoff_scripts debug_complete_handoff coder-test-driven` if failures persist",
       "fileRegex": [
         "^tests/.*\\.py$",
         "^src/.*\\.py$",
@@ -129,7 +129,7 @@
       "slug": "architect-highlevel-module",
       "name": "Architect",
       "roleDefinition": "Design high-level architecture that matches project goals.",
-      "customInstructions": "Outline modules with chain-of-thought reasoning and verify alignment with the blueprint. Document architecture in `docs/architecture.md` with complexity scoring and update a `state` signal.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps",
+      "customInstructions": "Outline modules with chain-of-thought reasoning and verify alignment with the blueprint. Document architecture in `docs/architecture.md` with complexity scoring and update a `state` signal.\nHANDOFF PROTOCOL: After completing your task:\n\u2022 Add 'state' signal documenting completion\n\u2022 Add 'need' signal for next required action\n\u2022 Specify target agent in signal\n\u2022 Use attempt_completion with next steps\nExample: run `python -m scripts.handoff_scripts architecture_complete_handoff` to notify the coder",
       "fileRegex": [
         "^docs/architecture.md$",
         "^docs/.*\\.md$",

--- a/scripts/handoff_scripts.py
+++ b/scripts/handoff_scripts.py
@@ -1,0 +1,66 @@
+import asyncio
+from typing import Any
+
+from src.pheromone_handler import PheromoneHandler
+from src.handoff_templates import task_completion, work_request
+
+
+async def _execute_signals(path: str, *signals: Any) -> None:
+    handler = PheromoneHandler(path)
+    for sig in signals:
+        await handler.add_signal(sig)
+
+
+async def blueprint_complete_handoff(path: str = ".pheromone") -> None:
+    """Route blueprint completion to the architect."""
+    done = task_completion("Blueprint finalized")
+    request = work_request(
+        "architecture design required",
+        "architect-highlevel-module",
+        strength=7.0,
+    )
+    await _execute_signals(path, done, request)
+
+
+async def architecture_complete_handoff(path: str = ".pheromone") -> None:
+    """Route architecture completion to the coder."""
+    done = task_completion("Architecture documented")
+    request = work_request(
+        "coding implementation needed",
+        "coder-test-driven",
+        strength=7.1,
+    )
+    await _execute_signals(path, done, request)
+
+
+async def code_complete_handoff(path: str = ".pheromone") -> None:
+    """Route code completion to the tester."""
+    done = task_completion("Code implemented")
+    request = work_request("run tests", "tester-tdd-master", strength=7.2)
+    await _execute_signals(path, done, request)
+
+
+async def test_complete_handoff(path: str = ".pheromone") -> None:
+    """Notify orchestrator that testing finished."""
+    done = task_completion("Testing complete")
+    request = work_request(
+        "review results",
+        "orchestrator-pheromone-scribe",
+        strength=7.3,
+    )
+    await _execute_signals(path, done, request)
+
+
+async def debug_complete_handoff(target: str, path: str = ".pheromone") -> None:
+    """Return debugging results to the requested agent."""
+    done = task_completion("Bug resolved")
+    request = work_request("retest fix", target, strength=7.4)
+    await _execute_signals(path, done, request)
+
+
+async def main() -> None:
+    await blueprint_complete_handoff()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/verify_handoffs.py
+++ b/scripts/verify_handoffs.py
@@ -1,0 +1,41 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+from src.pheromone_handler import PheromoneHandler
+from scripts.handoff_scripts import (
+    blueprint_complete_handoff,
+    architecture_complete_handoff,
+    code_complete_handoff,
+    test_complete_handoff,
+)
+from src.traffic_controller import determine_route
+
+
+async def verify_chain() -> bool:
+    path = Path(tempfile.mktemp())
+    handler = PheromoneHandler(str(path))
+    await blueprint_complete_handoff(str(path))
+    route = await determine_route(await handler.read_safe() or {}, handler)
+    if route != "architect-highlevel-module":
+        return False
+    await architecture_complete_handoff(str(path))
+    route = await determine_route(await handler.read_safe() or {}, handler)
+    if route != "coder-test-driven":
+        return False
+    await code_complete_handoff(str(path))
+    route = await determine_route(await handler.read_safe() or {}, handler)
+    if route != "tester-tdd-master":
+        return False
+    await test_complete_handoff(str(path))
+    route = await determine_route(await handler.read_safe() or {}, handler)
+    return route == "coder-test-driven"
+
+
+async def main() -> None:
+    result = await verify_chain()
+    print("handoff chain ok" if result else "handoff chain failed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/handoff_templates.py
+++ b/src/handoff_templates.py
@@ -1,0 +1,55 @@
+import time
+from typing import Any, Dict
+
+DEFAULT_TARGET = "orchestrator-pheromone-scribe"
+
+
+def _build(
+    signal_type: str, category: str, target: str, message: str, strength: float
+) -> Dict[str, Any]:
+    """Return a fully structured pheromone signal."""
+    return {
+        "id": f"{signal_type}-{int(time.time()*1000)}",
+        "signalType": signal_type,
+        "category": category,
+        "strength": strength,
+        "target": target,
+        "message": message,
+        "timestamp": int(time.time()),
+    }
+
+
+def task_completion(
+    message: str,
+    target: str = DEFAULT_TARGET,
+    strength: float = 7.5,
+) -> Dict[str, Any]:
+    """Template for announcing task completion."""
+    return _build("task_completed", "state", target, message, strength)
+
+
+def work_request(
+    message: str,
+    target: str,
+    strength: float = 7.0,
+) -> Dict[str, Any]:
+    """Template for requesting work from another agent."""
+    return _build("work_request", "need", target, message, strength)
+
+
+def coordination_signal(
+    message: str,
+    target: str,
+    strength: float = 6.5,
+) -> Dict[str, Any]:
+    """Template for coordinating complex handoffs."""
+    return _build("coordination", "coordinate", target, message, strength)
+
+
+def error_signal(
+    message: str,
+    target: str = DEFAULT_TARGET,
+    strength: float = 8.5,
+) -> Dict[str, Any]:
+    """Template for reporting errors or blocks."""
+    return _build("error_block", "block", target, message, strength)

--- a/tests/test_handoff_scripts.py
+++ b/tests/test_handoff_scripts.py
@@ -1,0 +1,36 @@
+import asyncio
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import pytest
+
+from scripts.handoff_scripts import (
+    blueprint_complete_handoff,
+    architecture_complete_handoff,
+    code_complete_handoff,
+    test_complete_handoff,
+    debug_complete_handoff,
+)
+from src.pheromone_handler import PheromoneHandler
+from src.traffic_controller import determine_route
+
+
+@pytest.mark.asyncio
+async def test_handoff_sequence(tmp_path: Path) -> None:
+    pher = tmp_path / "pher.json"
+    await blueprint_complete_handoff(str(pher))
+    handler = PheromoneHandler(str(pher))
+    agent = await determine_route(await handler.read_safe() or {}, handler)
+    assert agent == "architect-highlevel-module"
+    await architecture_complete_handoff(str(pher))
+    agent = await determine_route(await handler.read_safe() or {}, handler)
+    assert agent == "coder-test-driven"
+    await code_complete_handoff(str(pher))
+    agent = await determine_route(await handler.read_safe() or {}, handler)
+    assert agent == "tester-tdd-master"
+    await test_complete_handoff(str(pher))
+    agent = await determine_route(await handler.read_safe() or {}, handler)
+    assert agent == "coder-test-driven"
+    await debug_complete_handoff("tester-tdd-master", str(pher))
+    agent = await determine_route(await handler.read_safe() or {}, handler)
+    assert agent == "tester-tdd-master"

--- a/tests/test_handoff_templates.py
+++ b/tests/test_handoff_templates.py
@@ -1,0 +1,12 @@
+from src.handoff_templates import task_completion, work_request, coordination_signal, error_signal
+
+
+def test_signal_templates() -> None:
+    s1 = task_completion("done")
+    assert s1["category"] == "state"
+    s2 = work_request("work", "agent")
+    assert s2["target"] == "agent"
+    s3 = coordination_signal("coord", "agent2")
+    assert s3["category"] == "coordinate"
+    s4 = error_signal("err")
+    assert s4["strength"] >= 8.5

--- a/tests/test_verify_handoffs.py
+++ b/tests/test_verify_handoffs.py
@@ -1,0 +1,9 @@
+import asyncio
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from scripts.verify_handoffs import verify_chain
+
+
+def test_verify_chain() -> None:
+    assert asyncio.run(verify_chain())


### PR DESCRIPTION
## Summary
- add standardized signal templates for handoffs
- implement mode specific handoff scripts and verification script
- update .ROOMODES with handoff examples
- test handoff functionality

## Testing
- `pytest tests/ -q`
- `python src/traffic_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_68502c7d89f883228c85b4e4f75c56a9