### PR TITLE
Add health utilities and integration tests

### DIFF
--- a/docs/testing_protocol.md
+++ b/docs/testing_protocol.md
@@ -1,0 +1,22 @@
+# Testing Protocol
+
+Follow these steps to validate the Phero-Swarm system:
+
+1. **Validate JSON files**
+   ```bash
+   find . -name "*.json" -exec python -m json.tool {} \; > /dev/null
+   ```
+2. **Run the full test suite with coverage**
+   ```bash
+   pytest tests/ --cov=src --cov-report=term-missing
+   ```
+3. **Run system health validation**
+   ```bash
+   python validate_system_health.py
+   ```
+4. **Check coordination monitor**
+   ```bash
+   python coordination_monitor.py --once
+   ```
+
+All tests must pass with at least 80% coverage before deployment.

--- a/docs/troubleshooting_guide.md
+++ b/docs/troubleshooting_guide.md
@@ -1,0 +1,23 @@
+# Troubleshooting Guide
+
+Use this guide to resolve common issues with the Phero-Swarm system.
+
+## Diagnose Pheromone File
+```bash
+python diagnose_pheromone.py .pheromone
+```
+
+## Validate System Health
+```bash
+python validate_system_health.py
+```
+
+## Reset the System
+```bash
+python reset_phero_swarm.py
+```
+
+If problems persist, inspect recent signals using:
+```bash
+python coordination_monitor.py --once
+```

--- a/reset_phero_swarm.py
+++ b/reset_phero_swarm.py
@@ -1,0 +1,51 @@
+import asyncio
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Optional
+
+from src.pheromone_handler import PheromoneHandler
+from validate_system_health import (
+    check_config_files,
+    check_roomodes,
+    test_pheromone_ops,
+    verify_routing,
+    SystemHealthError,
+)
+
+
+class ResetError(Exception):
+    """Raised when system reset fails."""
+
+
+async def backup_state(path: Path) -> Optional[Path]:
+    if not path.exists():
+        return None
+    dest = path.with_suffix(f".bak.{int(time.time())}")
+    await asyncio.to_thread(shutil.copy2, path, dest)
+    return dest
+
+
+async def reset_pheromone(path: Path) -> None:
+    handler = PheromoneHandler(str(path))
+    data = {"signals": [], "metadata": {"created": int(time.time())}}
+    await handler.write_safe(data)
+
+
+async def main() -> None:
+    file_path = Path(os.getenv("PHEROMONE_FILE", ".pheromone"))
+    try:
+        await backup_state(file_path)
+        await reset_pheromone(file_path)
+        await check_config_files()
+        await check_roomodes()
+        await test_pheromone_ops()
+        await verify_routing()
+        print("System reset complete and healthy")
+    except (SystemHealthError, Exception) as exc:
+        raise ResetError("Reset failed") from exc
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_phero_swarm_integration.py
+++ b/tests/test_phero_swarm_integration.py
@@ -1,0 +1,112 @@
+import asyncio
+import time
+from pathlib import Path
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from coordination_monitor import CoordinationMonitor
+from src.pheromone_handler import PheromoneHandler, PheromoneHandlerError
+from src.traffic_controller import determine_route
+
+
+@pytest.mark.asyncio
+async def test_pheromone_corruption_resistance(tmp_path: Path) -> None:
+    path = tmp_path / "pher.json"
+    handler = PheromoneHandler(str(path))
+    good = {"signals": []}
+    await handler.write_safe(good)
+    path.write_text("{bad}")
+    assert await handler.read_safe() == good
+
+
+@pytest.mark.asyncio
+async def test_traffic_controller_routing_accuracy() -> None:
+    data = {"signals": [{"id": "1", "signalType": "req", "category": "need", "strength": 5.0, "message": "write tests", "timestamp": 1}]}
+    assert await determine_route(data) == "tester-tdd-master"
+
+
+@pytest.mark.asyncio
+async def test_mode_handoff_completion(tmp_path: Path) -> None:
+    handler = PheromoneHandler(str(tmp_path / "p.json"))
+    start = {"id": "1", "signalType": "start", "category": "compass", "strength": 5.0, "message": "idea", "timestamp": 1}
+    await handler.write_safe({"signals": [start]})
+    agent = await determine_route(await handler.read_safe(), handler)
+    assert agent == "concept-to-blueprint-translator"
+    await handler.clear_signals_by_category("compass")
+    await handler.add_signal({"id": "2", "signalType": "bp", "category": "need", "strength": 6.0, "message": "architecture", "timestamp": 2})
+    agent = await determine_route(await handler.read_safe(), handler)
+    assert agent == "architect-highlevel-module"
+
+
+@pytest.mark.asyncio
+async def test_signal_lifecycle_management(tmp_path: Path) -> None:
+    handler = PheromoneHandler(str(tmp_path / "p.json"))
+    await handler.write_safe({"signals": []})
+    sig = {"id": "1", "signalType": "t", "category": "need", "strength": 1.0, "message": "m", "timestamp": 1}
+    await handler.add_signal(sig)
+    data = await handler.read_safe()
+    assert len(data["signals"]) == 1
+    await handler.clear_signals_by_category("need")
+    data = await handler.read_safe()
+    assert data["signals"] == []
+
+
+@pytest.mark.asyncio
+async def test_error_recovery_mechanisms(tmp_path: Path) -> None:
+    path = tmp_path / "pher.json"
+    handler = PheromoneHandler(str(path))
+    old = {"id": "1", "signalType": "route", "category": "coordinate", "strength": 5.0, "target": "a", "message": "old", "timestamp": int(time.time()) - 400}
+    await handler.write_safe({"signals": [old]})
+    monitor = CoordinationMonitor(str(path), stall_min=1, expiry_min=5)
+    await monitor.check_once()
+    data = await handler.read_safe()
+    assert any(s.get("target") == "orchestrator-pheromone-scribe" for s in data["signals"])
+
+
+@pytest.mark.asyncio
+async def test_full_project_workflow(tmp_path: Path) -> None:
+    handler = PheromoneHandler(str(tmp_path / "p.json"))
+    await handler.write_safe({"signals": []})
+    await handler.add_signal({"id": "c1", "signalType": "new", "category": "compass", "strength": 5.0, "message": "start", "timestamp": 1})
+    agent = await determine_route(await handler.read_safe())
+    assert agent == "concept-to-blueprint-translator"
+    await handler.clear_signals_by_category("compass")
+    await handler.add_signal({"id": "c2", "signalType": "bp", "category": "need", "strength": 6.0, "message": "architecture plan", "timestamp": 2})
+    agent = await determine_route(await handler.read_safe())
+    assert agent == "architect-highlevel-module"
+    await handler.clear_signals_by_category("need")
+    await handler.add_signal({"id": "c3", "signalType": "design", "category": "need", "strength": 6.0, "message": "code implementation", "timestamp": 3})
+    agent = await determine_route(await handler.read_safe())
+    assert agent == "coder-test-driven"
+    await handler.clear_signals_by_category("need")
+    await handler.add_signal({"id": "c4", "signalType": "impl", "category": "need", "strength": 6.0, "message": "test cases", "timestamp": 4})
+    agent = await determine_route(await handler.read_safe())
+    assert agent == "tester-tdd-master"
+
+
+@pytest.mark.asyncio
+async def test_error_injection_and_recovery(tmp_path: Path) -> None:
+    path = tmp_path / "pher.json"
+    handler = PheromoneHandler(str(path))
+    await handler.write_safe({"signals": []})
+    path.write_text("{bad}")
+    assert await handler.read_safe() == {"signals": []}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_access_protection(tmp_path: Path) -> None:
+    handler = PheromoneHandler(str(tmp_path / "p.json"))
+    await handler.write_safe({"signals": []})
+    for i in range(5):
+        sig = {"id": str(i), "signalType": "t", "category": "need", "strength": 1.0, "message": "m", "timestamp": i}
+        await handler.add_signal(sig)
+    data = await handler.read_safe()
+    assert len(data["signals"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_signal_malformation_handling(tmp_path: Path) -> None:
+    handler = PheromoneHandler(str(tmp_path / "p.json"))
+    with pytest.raises(PheromoneHandlerError):
+        await handler.write_safe({"signals": [{}]})

--- a/validate_system_health.py
+++ b/validate_system_health.py
@@ -1,0 +1,81 @@
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+from src.pheromone_handler import PheromoneHandler, PheromoneHandlerError
+from src.traffic_controller import determine_route, RoutingError
+
+
+class SystemHealthError(Exception):
+    """Raised when system health checks fail."""
+
+
+async def check_config_files() -> None:
+    """Ensure core configuration files exist and are valid JSON."""
+    for name in [".swarmConfig", os.getenv("PHEROMONE_FILE", ".pheromone")]:
+        path = Path(name)
+        if not path.exists():
+            raise SystemHealthError(f"{name} missing")
+        try:
+            await asyncio.to_thread(json.load, open(path))
+        except json.JSONDecodeError as exc:
+            raise SystemHealthError(f"{name} invalid") from exc
+
+
+async def check_roomodes(path: str = ".roomodes") -> None:
+    """Validate mode definitions if present."""
+    file = Path(path)
+    if not file.exists():
+        print(f"Warning: {path} not found")
+        return
+    try:
+        await asyncio.to_thread(yaml.safe_load, file.read_text())
+    except yaml.YAMLError as exc:
+        raise SystemHealthError("roomodes malformed") from exc
+
+
+async def test_pheromone_ops() -> None:
+    """Read and immediately rewrite pheromone to ensure file operations work."""
+    handler = PheromoneHandler(os.getenv("PHEROMONE_FILE", ".pheromone"))
+    try:
+        data = await handler.read_safe()
+        if data is None:
+            raise SystemHealthError("pheromone unreadable")
+        await handler.write_safe(data)
+    except PheromoneHandlerError as exc:
+        raise SystemHealthError("pheromone handler failure") from exc
+
+
+async def verify_routing() -> None:
+    """Confirm traffic controller can route a simple signal."""
+    signal = {
+        "id": "health-check",
+        "signalType": "test",
+        "category": "need",
+        "strength": 5.0,
+        "message": "verify routing",
+        "timestamp": int(time.time()),
+    }
+    data = {"signals": [signal]}
+    agent = await determine_route(data)
+    if agent != "tester-tdd-master":
+        raise SystemHealthError("routing incorrect")
+
+
+async def main() -> None:
+    try:
+        await check_config_files()
+        await check_roomodes()
+        await test_pheromone_ops()
+        await verify_routing()
+        print("System healthy")
+    except SystemHealthError as exc:
+        print(f"Health issue: {exc}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add system validation script and reset utility
- provide integration test suite for pheromone and routing
- document testing protocol and troubleshooting steps

## Testing
- `find . -name "*.json" -exec python -m json.tool {} \; > /dev/null`
- `pytest tests/ --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68503453cf8c8322b57624eeb95bf37a