### PR TITLE
Optimize signal processing and add caching

### DIFF
--- a/src/pheromone_helpers.py
+++ b/src/pheromone_helpers.py
@@ -2,7 +2,26 @@ import asyncio
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Iterable
+
+import aiofiles
+
+from .signal_cache import SignalCache, SignalCacheError
+
+
+class FilePool:
+    """Simple async file connection pool."""
+
+    async def read(self, path: str) -> str:
+        async with aiofiles.open(path, "r") as handle:
+            return await handle.read()
+
+    async def write(self, path: str, text: str) -> None:
+        async with aiofiles.open(path, "w") as handle:
+            await handle.write(text)
+
+
+FILE_POOL = FilePool()
 from .signal_optimizer import consolidate_duplicates, normalize_strengths
 
 from .context_manager import compress_context, validate_files, extract_decisions
@@ -12,21 +31,31 @@ class PheromoneError(Exception):
     """Custom exception for pheromone update issues."""
 
 
-async def load_pheromone(path: str) -> Dict[str, Any]:
-    """Load pheromone JSON asynchronously."""
+async def load_pheromone(path: str, cache: SignalCache | None = None) -> Dict[str, Any]:
+    """Load pheromone JSON asynchronously with caching."""
+    if cache:
+        try:
+            return await cache.get(path)
+        except SignalCacheError:
+            pass
     try:
-        text = await asyncio.to_thread(Path(path).read_text)
-        return json.loads(text)
+        text = await FILE_POOL.read(path)
+        data = json.loads(text)
     except (OSError, json.JSONDecodeError) as exc:
         raise PheromoneError("Invalid pheromone file") from exc
+    if cache:
+        await cache.set(path, data)
+    return data
 
 
-async def save_pheromone(path: str, data: Dict[str, Any]) -> None:
-    """Persist pheromone JSON asynchronously."""
+async def save_pheromone(path: str, data: Dict[str, Any], cache: SignalCache | None = None) -> None:
+    """Persist pheromone JSON asynchronously with cache write-through."""
     try:
-        await asyncio.to_thread(Path(path).write_text, json.dumps(data, indent=2))
+        await FILE_POOL.write(path, json.dumps(data, indent=2))
     except OSError as exc:
         raise PheromoneError("Unable to save pheromone") from exc
+    if cache:
+        await cache.set(path, data)
 
 
 def calculate_strength(category: str, complexity: int, urgency: float) -> float:
@@ -53,16 +82,31 @@ def sanitize_context(context: Dict[str, Any]) -> Dict[str, Any]:
     return compress_context(context)
 
 
-async def update_pheromone(path: str, signal: Dict[str, Any]) -> None:
+async def update_pheromone(path: str, signal: Dict[str, Any], cache: SignalCache | None = None) -> None:
     """Update pheromone file with a sanitized signal."""
-    pheromone = await load_pheromone(path)
+    pheromone = await load_pheromone(path, cache)
     context = sanitize_context(signal.get("context", {}))
     signal["context"] = context
     pheromone.setdefault("signals", []).append(signal)
     pheromone["signals"] = consolidate_signals(pheromone["signals"])
     pheromone["signals"] = consolidate_duplicates(pheromone["signals"])
     pheromone["signals"] = normalize_strengths(pheromone["signals"])
-    await save_pheromone(path, pheromone)
+    await save_pheromone(path, pheromone, cache)
+
+
+async def batch_update_pheromone(path: str, signals: Iterable[Dict[str, Any]], cache: SignalCache | None = None) -> None:
+    """Apply a list of signals efficiently."""
+    pheromone = await load_pheromone(path, cache)
+    sanitized = []
+    for sig in signals:
+        ctx = sanitize_context(sig.get("context", {}))
+        sig["context"] = ctx
+        sanitized.append(sig)
+    pheromone.setdefault("signals", []).extend(sanitized)
+    pheromone["signals"] = consolidate_signals(pheromone["signals"])
+    pheromone["signals"] = consolidate_duplicates(pheromone["signals"])
+    pheromone["signals"] = normalize_strengths(pheromone["signals"])
+    await save_pheromone(path, pheromone, cache)
 
 
 def consolidate_signals(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/src/signal_cache.py
+++ b/src/signal_cache.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Awaitable
+
+
+class SignalCacheError(Exception):
+    """Raised when cache operations fail."""
+
+
+@dataclass
+class _Entry:
+    data: List[Dict[str, Any]]
+    timestamp: float
+
+
+class SignalCache:
+    """In-memory TTL cache with write-through persistence."""
+
+    def __init__(self, ttl: int | None = None, persist: Callable[[str, List[Dict[str, Any]]], Awaitable[None]] | None = None) -> None:
+        self.ttl = ttl or int(os.getenv("SIGNAL_CACHE_TTL", "60"))
+        self.persist = persist or (lambda _k, _v: asyncio.sleep(0))
+        self._cache: Dict[str, _Entry] = {}
+        self._metrics: Dict[str, int] = {"hits": 0, "misses": 0, "writes": 0}
+
+    async def get(self, key: str) -> List[Dict[str, Any]]:
+        entry = self._cache.get(key)
+        now = time.time()
+        if entry and now - entry.timestamp < self.ttl:
+            self._metrics["hits"] += 1
+            return entry.data
+        if entry:
+            self._cache.pop(key, None)
+        self._metrics["misses"] += 1
+        raise SignalCacheError("Cache miss")
+
+    async def set(self, key: str, value: List[Dict[str, Any]]) -> None:
+        self._cache[key] = _Entry(value, time.time())
+        self._metrics["writes"] += 1
+        try:
+            await self.persist(key, value)
+        except Exception as exc:  # noqa: BLE001
+            raise SignalCacheError("Persist failed") from exc
+
+    def invalidate(self, key: str) -> None:
+        self._cache.pop(key, None)
+
+    def metrics(self) -> Dict[str, int]:
+        return dict(self._metrics)

--- a/src/signal_optimizer.py
+++ b/src/signal_optimizer.py
@@ -7,7 +7,7 @@ class OptimizationError(Exception):
 
 
 def cluster_by_context(signals: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
-    """Group signals by context id or target."""
+    """Group signals by context id or target using defaultdict."""
     clusters: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for sig in signals:
         key = sig.get("context", {}).get("id") or sig.get("target") or "global"
@@ -16,9 +16,8 @@ def cluster_by_context(signals: List[Dict[str, Any]]) -> Dict[str, List[Dict[str
 
 
 def consolidate_duplicates(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Merge duplicate signals with matching type and context."""
-    seen: Dict[tuple, Dict[str, Any]] = {}
-    result: List[Dict[str, Any]] = []
+    """Merge duplicates using hash-based grouping."""
+    groups: Dict[tuple, List[Dict[str, Any]]] = defaultdict(list)
     for sig in signals:
         key = (
             sig.get("signalType"),
@@ -26,13 +25,15 @@ def consolidate_duplicates(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]
             sig.get("category"),
             sig.get("context", {}).get("id"),
         )
-        if key in seen:
-            exist = seen[key]
-            exist["message"] = f"{exist.get('message','')}; {sig.get('message','')}"
-            exist["strength"] = max(exist.get("strength", 0), sig.get("strength", 0))
-        else:
-            seen[key] = sig
-            result.append(sig)
+        groups[key].append(sig)
+
+    result: List[Dict[str, Any]] = []
+    for grp in groups.values():
+        base = grp[0]
+        if len(grp) > 1:
+            base["message"] = "; ".join(s.get("message", "") for s in grp)
+            base["strength"] = max(s.get("strength", 0) for s in grp)
+        result.append(base)
     return result
 
 
@@ -46,6 +47,16 @@ def normalize_strengths(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for sig in signals:
         sig["strength"] = round((sig.get("strength", 0) / max_val) * 10, 2)
     return signals
+
+
+def build_signal_index(signals: List[Dict[str, Any]]) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:
+    """Index signals by category and target for fast lookups."""
+    index: Dict[str, Dict[str, List[Dict[str, Any]]]] = defaultdict(lambda: defaultdict(list))
+    for sig in signals:
+        cat = sig.get("category") or "unknown"
+        tgt = sig.get("target") or "global"
+        index[cat][tgt].append(sig)
+    return {c: dict(t) for c, t in index.items()}
 
 
 async def adaptive_evaporation(

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,44 @@
+import asyncio
+import time
+from typing import List, Dict
+
+import pytest
+
+from src.signal_optimizer import consolidate_duplicates, build_signal_index
+
+
+def generate_signals(num: int) -> List[Dict[str, int]]:
+    return [
+        {
+            "signalType": "a",
+            "category": "need",
+            "target": f"t{i%10}",
+            "context": {"id": str(i % 5)},
+            "strength": i % 10,
+            "message": str(i),
+        }
+        for i in range(num)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_consolidate_performance() -> None:
+    data1 = generate_signals(1000)
+    start = time.perf_counter()
+    consolidate_duplicates(data1)
+    t1 = time.perf_counter() - start
+
+    data2 = generate_signals(2000)
+    start = time.perf_counter()
+    consolidate_duplicates(data2)
+    t2 = time.perf_counter() - start
+
+    assert t2 / t1 < 3
+
+
+@pytest.mark.asyncio
+async def test_build_index() -> None:
+    signals = generate_signals(100)
+    index = build_signal_index(signals)
+    assert "need" in index
+    assert list(index["need"].keys())

--- a/tests/test_pheromone_helpers_batch.py
+++ b/tests/test_pheromone_helpers_batch.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.signal_cache import SignalCache
+from src.pheromone_helpers import batch_update_pheromone, load_pheromone
+
+
+@pytest.mark.asyncio
+async def test_batch_update(tmp_path: Path) -> None:
+    p = tmp_path / "p.json"
+    p.write_text(json.dumps({"signals": []}))
+    cache = SignalCache(ttl=10)
+    signals = [
+        {"id": "1", "signalType": "t", "category": "need", "strength": 1, "message": "m", "timestamp": 1},
+        {"id": "2", "signalType": "t", "category": "need", "strength": 2, "message": "m", "timestamp": 2},
+    ]
+    await batch_update_pheromone(str(p), signals, cache)
+    data = await load_pheromone(str(p), cache)
+    assert len(data["signals"]) == 1
+    assert cache.metrics()["writes"] >= 1

--- a/tests/test_signal_cache.py
+++ b/tests/test_signal_cache.py
@@ -1,0 +1,50 @@
+import asyncio
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.signal_cache import SignalCache, SignalCacheError
+
+
+@pytest.mark.asyncio
+async def test_cache_set_and_get() -> None:
+    calls = []
+
+    async def persist(key, value):  # noqa: D401
+        calls.append((key, value))
+
+    cache = SignalCache(ttl=1, persist=persist)
+    await cache.set("k", ["v"])
+    result = await cache.get("k")
+    assert result == ["v"]
+    assert calls
+
+    await asyncio.sleep(1.1)
+    with pytest.raises(SignalCacheError):
+        await cache.get("k")
+
+
+@pytest.mark.asyncio
+async def test_cache_metrics() -> None:
+    cache = SignalCache(ttl=10)
+    with pytest.raises(SignalCacheError):
+        await cache.get("x")
+    await cache.set("x", ["a"])
+    await cache.get("x")
+    metrics = cache.metrics()
+    assert metrics["hits"] == 1
+    assert metrics["misses"] == 1
+    assert metrics["writes"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidate() -> None:
+    cache = SignalCache(ttl=10)
+    await cache.set("y", ["b"])
+    cache.invalidate("y")
+    with pytest.raises(SignalCacheError):
+        await cache.get("y")


### PR DESCRIPTION
## Summary
- optimize duplicate consolidation in `signal_optimizer`
- add signal indexing for faster lookups
- create `signal_cache` with TTL and metrics
- integrate cache and batching in `pheromone_helpers`
- add performance and cache tests

## Testing
- `pytest tests/ --cov=src/ --cov-report=term-missing`
- `python src/traffic_controller.py`

------
https://chatgpt.com/codex/tasks/task_e_685063b4a6308322ba9a1084b4880f92